### PR TITLE
fix!: update for hilbish 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 	<img src="showcase.png">
 </div>
 
-Delta is pretty, minimalist prompt for [Hilbish](https://github.com/Mewyuna/Hilbish),
+Delta is pretty, minimalist prompt for [Hilbish](https://github.com/Rosettea/Hilbish),
 inspired by [Pure](https://github.com/sindresorhus/pure).
 
 Delta shows all that you'll really need:
@@ -13,6 +13,8 @@ current working directory, git branch and if its dirty, and of course the delta
 prompt character.
 
 # Installation
+> Requires Hilbish 2.0+ (master branch or lua5.4 branch)
+
 ### Manually
 Clone this directory to one of the paths Hilbish looks for libraries at.
 ```

--- a/delta.lua
+++ b/delta.lua
@@ -2,19 +2,19 @@ local ansikit = require 'ansikit'
 local bait = require 'bait'
 local lunacolors = require 'lunacolors'
 
-function dirty()
+local function dirty()
 	local _, dirt = hilbish.run('git status --porcelain | wc -l', false)
 	dirt = dirt:gsub('\n', '')
 
 	return (dirt ~= '0' and '*' or '')
 end
 
-function isgitrepo()
+local function isgitrepo()
 	local code = hilbish.run 'git rev-parse --git-dir > /dev/null 2>&1'
 	return code == 0
 end
 
-function branch()
+local function branch()
 	local _, gitbranch = hilbish.run('git rev-parse --abbrev-ref HEAD', false)
 
 	return gitbranch:gsub('\n', '')

--- a/delta.lua
+++ b/delta.lua
@@ -3,24 +3,21 @@ local bait = require 'bait'
 local lunacolors = require 'lunacolors'
 
 function dirty()
-	local res = io.popen 'git status --porcelain | wc -l'
-	local dirt = res:read():gsub('\n', '')
-	res:close()
+	local _, dirt = hilbish.run('git status --porcelain | wc -l', false)
+	dirt = dirt:gsub('\n', '')
 
 	return (dirt ~= '0' and '*' or '')
 end
 
 function isgitrepo()
-	local code = os.execute 'git rev-parse --git-dir > /dev/null 2>&1'
+	local code = hilbish.run 'git rev-parse --git-dir > /dev/null 2>&1'
 	return code == 0
 end
 
 function branch()
-	local res = io.popen 'git rev-parse --abbrev-ref HEAD 2> /dev/null'
-	local gitbranch = res:read()
-	res:close()
+	local _, gitbranch = hilbish.run('git rev-parse --abbrev-ref HEAD', false)
 
-	return gitbranch
+	return gitbranch:gsub('\n', '')
 end
 
 local delta = {}
@@ -55,8 +52,9 @@ function delta.init(o)
 	prompt(delta.prompt(0, opts))
 
 	bait.catch('command.exit', function(code)
-		prompt(delta.prompt(code, opts))
+		local p = delta.prompt(code, opts)
+		prompt(p)
 	end)
-
 end
+
 return delta

--- a/delta.lua
+++ b/delta.lua
@@ -43,17 +43,16 @@ end
 
 function delta.init(o)
 	local opts = {}
-	prompt = prompt or hilbish.prompt -- pre 1.0
 	o = o or {
 		shlvl = 3
 	}
 	setmetatable(opts, {__index = o})
 
-	prompt(delta.prompt(0, opts))
+	hilbish.prompt(delta.prompt(0, opts))
 
 	bait.catch('command.exit', function(code)
 		local p = delta.prompt(code, opts)
-		prompt(p)
+		hilbish.prompt(p)
 	end)
 end
 


### PR DESCRIPTION
upcoming hilbish 2.0 doesn't have io.popen, so use hilbish.run instead
will merge when its released, or when the lua 5.4 branch is merged